### PR TITLE
UF Chapter: Interactive Role Section

### DIFF
--- a/src/app/chapters/uf/page.tsx
+++ b/src/app/chapters/uf/page.tsx
@@ -1,4 +1,5 @@
 import VideoPlayer from '@/components/VideoPlayer'
+import ContentSection from '@/components/RoleDescription'
 
 export const metadata = {
   title: 'Off the Battlefield Foundation - University of Florida Chapter',
@@ -38,18 +39,76 @@ export default function Home() {
       height: '40px',
       marginRight: '10px',
     },
+    description: {
+      chapter_name: 'University of Florida Chapter',
+      background_color: 'white',
+      borderColor: 'green',
+      borderRadius: '15px',
+      borderWidth: '4px',
+      padding: '10px 20px',
+      fontSize: '14px',
+      fontWeight: 'bold',
+      textColor: '#333',
+      boxShadow: '0px 4px 6px rgba(0, 0, 0, 0.1)',
+    },
   }
+
+  const descriptionStyles = {
+    backgroundColor: settings.description.background_color,
+    border: `${settings.description.borderWidth} solid ${settings.description.borderColor}`,
+    borderRadius: settings.description.borderRadius,
+    padding: settings.description.padding,
+    fontSize: settings.description.fontSize,
+    fontWeight: settings.description.fontWeight,
+    color: settings.description.textColor,
+    boxShadow: settings.description.boxShadow,
+    zIndex: 10,
+  }
+
+  const items = [
+    {
+      title: 'Civil Engineering',
+      message:
+        'Working with UF engineering students and Nizhyn city civil engineers to support the repair of a damaged aeration pond vital to Nizhyn’s water infrastructure and the Oster River, a primary water source for Kyiv and downstream communities. In partnership with Nizhyn Lyceum, we will collect necessary data, fundraise for construction materials, assist in blueprint design, and promote environmental stewardship through a public awareness campaign.',
+    },
+    {
+      title: 'Public Health',
+      message:
+        'Collaborating with Feeding Futures, Gators for Refugee Medical Relief (GRMR), and the UF Ukrainian Student Association to distribute care packages with essential grains, non-perishable foods, and first-aid medical supplies, addressing the urgent resident needs in Nizhyn.',
+    },
+    {
+      title: 'Prosthetics',
+      message:
+        'Partnering with Generational Relief in Prosthetics (GRiP) to design affordable prostheses for veteran and civilian amputees. Our team has already scanned a Nizhyn veteran’s arm and began working on 3D model development for the prototype.',
+    },
+    {
+      title: 'Agriculture',
+      message:
+        'Collaborating with Nizhyn Lyceum, PK Yonge, and UF Internet of Things Students Club (IoT) to continue developing an AI-driven submarine drone for water quality monitoring. We will conduct interviews with local farmers, which will inform the drone’s implementation and highlight how conflict disrupts Ukraine’s water and agriculture sectors, amplifying their voices globally.',
+    },
+    {
+      title: 'Cultural Affairs',
+      message:
+        'Partnering with the UF International Center (UFIC) and Nizhyn Gogol State University (NGSU) to facilitate virtual student exchanges, fostering intercultural dialogue and resilience. Training for UF participants will be developed in collaboration with UF’s Counseling and Wellness Center (CWC) and the English Language Institute (ELI).',
+    },
+  ]
 
   return (
     <>
       <main style={{ margin: 0, padding: 0 }}>
-        <div style={{ margin: '20px 0', padding: '5%' }}>
+        <div style={{ margin: '20px 0', padding: '5% 5% 1% 5%' }}>
           <VideoPlayer
             videoSettings={settings.video}
             overlaySettings={settings.overlay}
             logoSettings={settings.logo}
           />
         </div>
+
+        <ContentSection
+          descriptionStyles={descriptionStyles}
+          items={items}
+          chapterName={settings.description.chapter_name}
+        />
       </main>
     </>
   )

--- a/src/components/RoleDescription.tsx
+++ b/src/components/RoleDescription.tsx
@@ -1,0 +1,101 @@
+interface Item {
+    title: string
+    message: string
+  }
+  
+  interface ContentSectionProps {
+    descriptionStyles: React.CSSProperties
+    items: Item[]
+    chapterName: string
+  }
+  
+  export default function ContentSection({
+    descriptionStyles,
+    items,
+    chapterName,
+  }: ContentSectionProps) {
+    return (
+      <>
+        <div style={{ margin: '1% 40% 0% 5%', ...descriptionStyles }}>
+          <span style={{ color: 'green' }}>#</span>&nbsp;Welcome to {chapterName}
+        </div>
+  
+        <div
+          style={{
+            margin: '1% 35% 5% 5%',
+            flexDirection: 'column',
+            alignItems: 'flex-start',
+            ...descriptionStyles,
+          }}
+        >
+          <span style={{ color: '#282F34', fontSize: 32 }}>
+            Why You Should Join Us:
+          </span>
+          <span style={{ color: '#2EB872', fontSize: 32 }}>
+            &nbsp;The Ukraine Rebuilding Initiative
+          </span>
+          <p
+            style={{
+              color: '#282F34',
+              fontSize: 16,
+              marginTop: '10px',
+              fontWeight: 'normal',
+            }}
+          >
+            The initiative is structured around five key division-based projects,
+            each targeting a specific area of development and rehabilitation in
+            Ukraine.
+          </p>
+  
+          <div style={{ marginTop: '20px' }}>
+            {items.map((item, index) => (
+              <details
+                key={index}
+                style={{
+                  marginBottom: '10px',
+                  padding: '2% 2% 2% 4%',
+                  border: descriptionStyles.border,
+                  borderRadius: '10px',
+                  backgroundColor: '#f9fcf0',
+                  cursor: 'pointer',
+                  fontSize: '18px',
+                }}
+              >
+                <summary
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    fontWeight: 'bold',
+                    color: '#282F34',
+                    cursor: 'pointer',
+                    listStyle: 'none',
+                  }}
+                >
+                  <span
+                    style={{
+                      color: '#2EB872',
+                      fontSize: '18px',
+                      marginRight: '10px',
+                    }}
+                  >
+                    ✓⃝
+                  </span>
+                  {item.title}
+                </summary>
+                <p
+                  style={{
+                    marginTop: '10px',
+                    color: '#555',
+                    fontWeight: 'normal',
+                    fontSize: 16,
+                  }}
+                >
+                  {item.message}
+                </p>
+              </details>
+            ))}
+          </div>
+        </div>
+      </>
+    )
+  }


### PR DESCRIPTION
Misha Requested a more interactive Role Description section. Here is how it looks like

<img width="1310" alt="image" src="https://github.com/user-attachments/assets/31c0169e-0928-431c-badb-bfbea7fdbeef" />

Upon clicking on any of the items, it exapnds with the description of the role: 

<img width="1310" alt="image" src="https://github.com/user-attachments/assets/d29ddc5e-07ff-46f2-8755-f929308387e1" />

Solves #12 
